### PR TITLE
Docker: Fix condition of recording by session capability se:recordVideo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -773,15 +773,29 @@ File name will be trimmed to 255 characters to avoid long file names. Moreover, 
 
 The trim regex is able to be customized by setting `SE_VIDEO_FILE_NAME_TRIM_REGEX` environment variable. The default value is `[^a-zA-Z0-9-_]`. The regex should be compatible with Python `re.compile()` function.
 
-At deployment level, the recorder container is up always. In addition, you can disable video recording process via session capability `se:recordVideo`. For example in Python binding:
+At deployment level, the recorder container is always up and stays in standby, watching for sessions. Whether a given session is recorded is controlled per session by the `se:recordVideo` capability, which overrides the `SE_RECORD_VIDEO` environment variable used as the default when the capability is not present:
+
+- `se:recordVideo` capability **present** on the session: its value wins for that session (`true` records, `false` skips), regardless of `SE_RECORD_VIDEO`.
+- `se:recordVideo` capability **absent**: the recorder falls back to `SE_RECORD_VIDEO` (default `true` for the standalone video image, `false` for the Node images).
+
+This means you can keep recording disabled by default and opt in per test. For example, with `SE_RECORD_VIDEO=false`, the recorder stays in standby and only records sessions that explicitly request it:
+
+```python
+# Recorded only because the session opts in, even when SE_RECORD_VIDEO=false
+options.set_capability('se:recordVideo', True)
+```
+
+Conversely, with recording enabled by default (`SE_RECORD_VIDEO=true`) you can disable it for a specific session:
 
 ```python
 options.set_capability('se:recordVideo', False)
 ```
 
-In recorder container will perform query GraphQL in Hub based on Node SessionId and extract the value of `se:recordVideo` in capabilities before deciding to start video recording process or not.
+This per-session control applies to both recording modes:
+- **Event-driven mode** (`SE_VIDEO_EVENT_DRIVEN=true`, default in the Node images): the recorder subscribes to the Grid event bus and reads `se:recordVideo` from each session's capabilities on the `SessionCreated` event.
+- **Shell/polling mode** (`SE_VIDEO_EVENT_DRIVEN=false`): the recorder queries the Node `/status` endpoint (or the Hub GraphQL endpoint) based on the Node SessionId and extracts `se:recordVideo` from the capabilities before deciding whether to start recording.
 
-Notes: To reach the GraphQL endpoint, the recorder container needs to know the Hub URL. The Hub URL can be passed via environment variable `SE_NODE_GRID_URL`. For example `SE_NODE_GRID_URL` is `http://selenium-hub:4444`.
+Notes: For the shell/polling mode to reach the GraphQL endpoint, the recorder container needs to know the Hub URL. The Hub URL can be passed via environment variable `SE_NODE_GRID_URL`. For example `SE_NODE_GRID_URL` is `http://selenium-hub:4444`.
 
 ## Video recording and uploading
 

--- a/Video/video_graphQLQuery.py
+++ b/Video/video_graphQLQuery.py
@@ -231,13 +231,16 @@ def main(argv: list[str]) -> int:
         session_id, video_cap_name, test_name_cap, video_name_cap
     )
 
-    # Determine RECORD_VIDEO value
-    record_video = True
-    if isinstance(record_video_raw, str):
-        if record_video_raw.lower() == "false":
-            record_video = False
-    elif record_video_raw is False:
-        record_video = False
+    # Determine RECORD_VIDEO value. When the se:recordVideo capability is absent
+    # (record_video_raw is None), fall back to the SE_RECORD_VIDEO env default so
+    # SE_RECORD_VIDEO=false is honored, consistent with video_nodeQuery.py.
+    default_record_video = os.getenv("SE_RECORD_VIDEO", "true").lower() != "false"
+    if record_video_raw is None:
+        record_video = default_record_video
+    elif isinstance(record_video_raw, str):
+        record_video = record_video_raw.lower() != "false"
+    else:
+        record_video = bool(record_video_raw)
 
     # Decide TEST_NAME referencing precedence (video_name first, then test_name)
     chosen_name: str = ""

--- a/Video/video_service.py
+++ b/Video/video_service.py
@@ -172,6 +172,10 @@ class VideoService:
 
         # Capability names
         self.video_cap_name = os.environ.get("VIDEO_CAP_NAME", "se:recordVideo")
+        # Default recording state used when the se:recordVideo capability is absent
+        # on a session. Mirrors the fallback in the shell-mode helper (video_nodeQuery.py)
+        # so SE_RECORD_VIDEO=false is honored across both recording modes.
+        self.default_record_video = os.environ.get("SE_RECORD_VIDEO", "true").lower() != "false"
         self.test_name_cap = os.environ.get("TEST_NAME_CAP", "se:name")
         self.video_name_cap = os.environ.get("VIDEO_NAME_CAP", "se:videoName")
         self.file_name_trim_regex = os.environ.get("SE_VIDEO_FILE_NAME_TRIM_REGEX", "[^a-zA-Z0-9-_]")
@@ -260,10 +264,20 @@ class VideoService:
         return normalized[:251]
 
     def get_video_filename(self, session_id: str, capabilities: dict) -> tuple[bool, str]:
-        """Determine video filename from session capabilities."""
-        record_video = capabilities.get(self.video_cap_name, True)
-        if isinstance(record_video, str):
+        """Determine video filename from session capabilities.
+
+        Recording is gated by the se:recordVideo capability when it is present on
+        the session; when the capability is absent, it falls back to the
+        SE_RECORD_VIDEO environment default. This keeps the event-driven service
+        consistent with the shell-mode helper (video_nodeQuery.py).
+        """
+        record_video = capabilities.get(self.video_cap_name)
+        if record_video is None:
+            record_video = self.default_record_video
+        elif isinstance(record_video, str):
             record_video = record_video.lower() != "false"
+        else:
+            record_video = bool(record_video)
 
         if self.configured_video_file_name.lower() != "auto":
             fixed_name = self.configured_video_file_name

--- a/docker-compose-v3-video-in-node.yml
+++ b/docker-compose-v3-video-in-node.yml
@@ -16,7 +16,6 @@ services:
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_RECORD_VIDEO=true
-      - SE_VIDEO_FILE_NAME=auto
       - SE_NODE_GRID_URL=http://selenium-hub:4444
 
   edge:
@@ -33,7 +32,6 @@ services:
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_RECORD_VIDEO=true
-      - SE_VIDEO_FILE_NAME=auto
       - SE_NODE_GRID_URL=http://selenium-hub:4444
 
   firefox:
@@ -49,7 +47,6 @@ services:
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_RECORD_VIDEO=true
-      - SE_VIDEO_FILE_NAME=auto
       - SE_NODE_GRID_URL=http://selenium-hub:4444
 
   selenium-hub:


### PR DESCRIPTION
### Description
This change ensures that the `SE_RECORD_VIDEO` environment variable is consistently honored across both event-driven and shell-mode video recording. Previously, when the `se:recordVideo` capability was absent from a session, the code would default to `true` regardless of the `SE_RECORD_VIDEO` environment setting.

The fix implements a fallback mechanism in both `video_service.py` and `video_graphQLQuery.py`:
- When `se:recordVideo` capability is present on the session, it takes precedence
- When the capability is absent (`None`), the code now falls back to the `SE_RECORD_VIDEO` environment variable (defaulting to `"true"` if not set)
- Improved handling of different value types (string, boolean, etc.) with explicit type conversion

This brings consistency with the shell-mode helper (`video_nodeQuery.py`) and ensures `SE_RECORD_VIDEO=false` is respected in all recording modes.

### Motivation and Context
Users setting `SE_RECORD_VIDEO=false` to disable video recording would find it ignored when sessions didn't explicitly include the `se:recordVideo` capability. This inconsistency between event-driven and shell-mode recording behavior could lead to unexpected video files being generated.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] I have read the contributing document
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

https://claude.ai/code/session_01GS9nWJdMQedyVKojiSEkbh